### PR TITLE
Update to use node.js LTS (currently 14) & npm 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,12 @@
 {
   "name": "move-to-parent-merging-webpack-plugin",
   "version": "0.0.2",
-  "lockfileVersion": 1
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.2",
+      "license": "MIT"
+    }
+  }
 }


### PR DESCRIPTION
This updates to use node.js version 14, and npm 7. This uses the new npm 7
lockfile format.

This was a semi-automatically generated PR